### PR TITLE
Easier (and faster) chunk and inplace under nograd

### DIFF
--- a/palm_rlhf_pytorch/palm_rlhf_pytorch.py
+++ b/palm_rlhf_pytorch/palm_rlhf_pytorch.py
@@ -26,7 +26,10 @@ class Residual(nn.Module):
         self.fn = fn
 
     def forward(self, x):
-        return self.fn(x) + x
+        y = self.fn(x)
+        if not y.requires_grad and not x.requires_grad:
+            return x.add_(y)
+        return y + x
 
 
 # rotary positional embedding
@@ -46,8 +49,7 @@ class RotaryEmbedding(nn.Module):
 
 
 def rotate_half(x):
-    x = rearrange(x, "... (j d) -> ... j d", j=2)
-    x1, x2 = x.unbind(dim=-2)
+    x1, x2 = x.chunk(2, dim=-1)
     return torch.cat((-x2, x1), dim=-1)
 
 


### PR DESCRIPTION
Minor tricks. Proof

```python
import torch as th
from einops import rearrange

n = 64
x = th.arange(n).repeat(1, 1)
x.shape # (1, n)

%%timeit
x_ = rearrange(x, "... (j d) -> ... j d", j=2)
x1, x2 = x_.unbind(dim=-2)

%timeit x1, x2 = x.chunk(2, dim=-1)

x_ = rearrange(x, "... (j d) -> ... j d", j=2)
x1, x2 = x_.unbind(dim=-2)

new_x1, new_x2 = x.chunk(2, dim=-1)
assert th.allclose(x1, new_x1)
assert th.allclose(x2, new_x2)
```