### PR TITLE
Bug fix: Correct function call in RewardModel->finetune_parameters

### DIFF
--- a/palm_rlhf_pytorch/palm_rlhf_pytorch.py
+++ b/palm_rlhf_pytorch/palm_rlhf_pytorch.py
@@ -526,7 +526,7 @@ class RewardModel(nn.Module):
     def finetune_parameters(self):
         return [
             *self.to_pred.parameters(),
-            *palm.finetune_parameters(self.reward_lora_scope)
+            *self.palm.finetune_parameters(self.reward_lora_scope)
         ]
 
     def forward(


### PR DESCRIPTION
seems like it's missing `self` call for `finetune_parameters`
https://github.com/lucidrains/PaLM-rlhf-pytorch/blob/795da603f5bde77d028ad05f7d8172189bfb7a2a/palm_rlhf_pytorch/palm_rlhf_pytorch.py#L529