### PR TITLE
implement an argument to directly set ff_inner_dim

### DIFF
--- a/palm_rlhf_pytorch/palm.py
+++ b/palm_rlhf_pytorch/palm.py
@@ -124,6 +124,7 @@ class ParallelTransformerBlock(nn.Module):
         qk_rmsnorm = False,
         qk_scale = 8,
         ff_mult = 4,
+        ff_inner_dim = None,
         attn_dropout = 0.,
         ff_dropout = 0.,
         use_xpos = True,
@@ -134,7 +135,8 @@ class ParallelTransformerBlock(nn.Module):
         self.norm = LayerNorm(dim)
 
         attn_inner_dim = dim_head * heads
-        ff_inner_dim = dim * ff_mult
+        # silently ignores ff_mult if ff_inner_dim is provided in the arguments
+        ff_inner_dim = dim * ff_mult if not ff_inner_dim else self.ff_inner_dim
         self.fused_dims = (attn_inner_dim, dim_head, dim_head, (ff_inner_dim * 2))
 
         self.qk_rmsnorm = qk_rmsnorm
@@ -270,6 +272,7 @@ class PaLM(nn.Module):
         dim_head = 64,
         heads = 8,
         ff_mult = 4,
+        ff_inner_dim = None,
         attn_dropout = 0.,
         ff_dropout = 0.,
         qk_rmsnorm = False,
@@ -297,6 +300,7 @@ class PaLM(nn.Module):
                 heads = heads,
                 qk_rmsnorm = qk_rmsnorm,
                 ff_mult = ff_mult,
+                ff_inner_dim = ff_inner_dim,
                 attn_dropout = attn_dropout,
                 ff_dropout = ff_dropout,
                 xpos_scale_base = rotary_xpos_scale_base,


### PR DESCRIPTION
In NVIDIA [nvidia/GPT-2B-001](https://huggingface.co/nvidia/GPT-2B-001),  a very PaLM like model is implemented. 

However, instead of a ffn multiplier like `ffn_mult` the `ffn_hidden_size` (comparable to `ffn_inner_dim` of this codebase) is directly set as 5440.

This translates to a `ffn_mult` of `2.65625`. However, trying this in this codebase does not work.

The error

```
TypeError: empty() received an invalid combination of arguments - got (tuple, dtype=NoneType, device=NoneType), but expected one of:
 * (tuple of ints size, *, tuple of names names, torch.memory_format memory_format, torch.dtype dtype, torch.layout layout, torch.device device, bool pin_memory, bool requires_grad)
 * (tuple of ints size, *, torch.memory_format memory_format, Tensor out, torch.dtype dtype, torch.layout layout, torch.device device, bool pin_memory, bool requires_grad)
```

So I implemented a way to directly set the `ffn_inner_dim`
please take a look!